### PR TITLE
Adding `errors.Wrapper`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 sudo: false
 before_install:
         - .travis/longlines.sh
-        - .travis/gometalinter.sh
+        - .travis/golangci-lint.sh
         - go get github.com/mattn/goveralls
 script:
         - $HOME/gopath/bin/goveralls -service=travis-ci

--- a/.travis/golangci-lint.sh
+++ b/.travis/golangci-lint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -eu
+
+go get -t -u -v github.com/golangci/golangci-lint/cmd/golangci-lint
+
+echo "Running golangci-lint..."
+golangci-lint run -v ./...
+#golangci-lint run -v --enable-all ./...
+
+echo "No golangci-lint issues found."
+

--- a/errors/wrapper.go
+++ b/errors/wrapper.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 )
 
-// Wrapper provides a convenient mechanism for wrapping a number of erros with
-// a common prefix.
+// Wrapper provides a convenient mechanism for wrapping a number of errors
+// with a common prefix.
 type Wrapper string
 
 // AppendedWith gives another Wrapper with the additional string appended to

--- a/errors/wrapper.go
+++ b/errors/wrapper.go
@@ -1,0 +1,24 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// Wrapper provides a convenient mechanism for wrapping a number of erros with
+// a common prefix.
+type Wrapper string
+
+// AppendedWith gives another Wrapper with the additional string appended to
+// the prefix which will be added to any subsequent errors.
+func (w Wrapper) AppendedWith(s string) Wrapper {
+	return Wrapper(fmt.Sprintf("%s: %s", string(w), s))
+}
+
+// Wrap prepends the previously set prefix to the given non-nil error. It will
+// refrain from wrapping a nil error.
+func (w Wrapper) Wrap(err error) error {
+	if nil != err {
+		return fmt.Errorf("%s: %s", string(w), err.Error())
+	}
+	return nil
+}

--- a/errors/wrapper_test.go
+++ b/errors/wrapper_test.go
@@ -1,0 +1,29 @@
+package errors
+
+import (
+	"fmt"
+)
+
+func ExampleWrapper() {
+	wrapper := Wrapper("Error in wrapper test")
+	appendedWrapper := wrapper.AppendedWith("Appended error")
+
+	baseErr1 := New("Some error")
+	err1 := appendedWrapper.Wrap(baseErr1)
+
+	err2 := wrapper.Wrap(nil)
+
+	baseErr3 := fmt.Errorf("Yet another %s", "error")
+	err3 := wrapper.Wrap(baseErr3)
+
+	fmt.Printf(
+		"err1 is = %v\nerr2 is = %v\nerr3 is = %v\n",
+		err1,
+		err2,
+		err3,
+	)
+	// Output:
+	// err1 is = Error in wrapper test: Appended error: Some error
+	// err2 is = <nil>
+	// err3 is = Error in wrapper test: Yet another error
+}


### PR DESCRIPTION
`errors.Wrapper` provides a convenient mechanism for wrapping a number of errors with a common prefix.

Usage:
```golang
import (
	"fmt"
	"github.com/proidiot/gone/errors"
)

 func ExampleWrapper() {
	wrapper := errors.Wrapper("Error in wrapper test")
	appendedWrapper := wrapper.AppendedWith("Appended error")

 	baseErr1 := errors.New("Some error")
	err1 := appendedWrapper.Wrap(baseErr1)

 	err2 := wrapper.Wrap(nil)

 	baseErr3 := fmt.Errorf("Yet another %s", "error")
	err3 := wrapper.Wrap(baseErr3)

 	fmt.Printf(
		"err1 is = %v\nerr2 is = %v\nerr3 is = %v\n",
		err1,
		err2,
		err3,
	)
	// Output:
	// err1 is = Error in wrapper test: Appended error: Some error
	// err2 is = <nil>
	// err3 is = Error in wrapper test: Yet another error
}
```